### PR TITLE
Fix per-call memory leak of the work buffer's Vec header in `minimize`

### DIFF
--- a/src/slsqp.rs
+++ b/src/slsqp.rs
@@ -655,9 +655,8 @@ unsafe fn nlopt_compute_rescaling(
     //     (::std::mem::size_of::<::core::ffi::c_double>() as ::core::ffi::c_ulong).wrapping_mul(n as ::core::ffi::c_ulong),
     // ) as *mut ::core::ffi::c_double;
 
-    let mut space: Box<Vec<::core::ffi::c_double>> = Box::new(vec![0.; usize::try_from(n).unwrap()]);
-    let s = space.as_mut_ptr() as *mut ::core::ffi::c_double;
-    std::mem::forget(space);
+    let space = vec![0.; usize::try_from(n).unwrap()].into_boxed_slice();
+    let s = Box::into_raw(space) as *mut ::core::ffi::c_double;
 
     let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
@@ -741,9 +740,8 @@ unsafe fn nlopt_new_rescaled(
     //     (::std::mem::size_of::<::core::ffi::c_double>() as ::core::ffi::c_ulong).wrapping_mul(n as ::core::ffi::c_ulong),
     // ) as *mut ::core::ffi::c_double;
 
-    let mut space: Box<Vec<::core::ffi::c_double>> = Box::new(vec![0.; usize::try_from(n).unwrap()]);
-    let xs = space.as_mut_ptr() as *mut ::core::ffi::c_double;
-    std::mem::forget(space);
+    let space = vec![0.; usize::try_from(n).unwrap()].into_boxed_slice();
+    let xs = Box::into_raw(space) as *mut ::core::ffi::c_double;
 
     if xs.is_null() {
         return ::core::ptr::null_mut::<::core::ffi::c_double>();

--- a/src/slsqp.rs
+++ b/src/slsqp.rs
@@ -3777,10 +3777,8 @@ pub(crate) unsafe fn nlopt_slsqp<U>(
         .wrapping_add(max_cdim.wrapping_mul(n))
         .wrapping_add(len_w as ::core::ffi::c_uint)
         .wrapping_add(len_jw as ::core::ffi::c_uint); // size_of(::core::ffi::c_double) > size_of(::core::ffi::c_int)
-    let mut space: Box<Vec<::core::ffi::c_double>> =
-        Box::new(vec![0.; usize::try_from(space_size).unwrap()]);
-    work = space.as_mut_ptr() as *mut ::core::ffi::c_double;
-    std::mem::forget(space);
+    let mut space: Vec<::core::ffi::c_double> = vec![0.; usize::try_from(space_size).unwrap()];
+    work = space.as_mut_ptr();
 
     if work.is_null() {
         return NLOPT_OUT_OF_MEMORY;
@@ -4087,7 +4085,6 @@ pub(crate) unsafe fn nlopt_slsqp<U>(
             );
         }
     }
-    // free(work as *mut ::core::ffi::c_void);
-    let _ = Box::from_raw(work);
+    // `space` (the buffer behind `work`) is dropped here.
     return ret;
 }


### PR DESCRIPTION
Hi, thanks for maintaining this crate!

## Problem

While running `minimize` in a long-lived process, we noticed the heap growing by a small constant amount on every call. LeakSanitizer traced it to the work-buffer allocation in `nlopt_slsqp`:

```rust
let mut space: Box<Vec<::core::ffi::c_double>> =
    Box::new(vec![0.; usize::try_from(space_size).unwrap()]);
work = space.as_mut_ptr() as *mut ::core::ffi::c_double;
std::mem::forget(space);
...
let _ = Box::from_raw(work);
```

`Box<Vec<f64>>` performs two allocations: one for the `Vec` data and another for the `Vec` header. Only the data pointer is retained, which makes the separately allocated header unreachable.

On the tested 64-bit target, LeakSanitizer reports 24 B leaked per call. glibc retains a 32-byte chunk after alignment and allocator bookkeeping.

`Box::from_raw(work)` also reconstructs a `Box<f64>`, so it deallocates the work buffer with an 8-byte layout instead of its allocation layout. glibc tolerates this mismatch, but size-aware allocators can fail.

The same `Box<Vec<f64>>` allocation pattern appears in `nlopt_compute_rescaling` and `nlopt_new_rescaled`.

## Fix

`nlopt_slsqp` now owns its work buffer with a local `Vec<f64>`. The raw `work` pointer remains valid for the function’s lifetime, and the vector is dropped at the function’s single exit.

`nlopt_compute_rescaling` and `nlopt_new_rescaled` now allocate their returned buffers as `Box<[f64]>` and transfer ownership with `Box::into_raw`. This removes the separate `Vec` header allocation. The caller remains responsible for reconstructing the boxed slice with the original length and releasing it.

## Verification

I ran glibc `mallinfo2` A/B probes at `opt-level = "z"`. Each probe used 100 warm-up calls followed by 10,000 measured calls.

| Path | Before | After |
|---|---:|---:|
| `minimize` | 320,000 B total, 32 B/call | 0 B |
| `nlopt_compute_rescaling` | 320,000 B total, 32 B/call | 0 B |
| `nlopt_new_rescaled` | 320,000 B total, 32 B/call | 0 B |

`cargo test --all` and `cargo test --all --release` pass. Solver outputs on our workloads remain bit-for-bit unchanged.

Thanks for taking a look!
